### PR TITLE
Add fm3._domainkey to DKIM setup

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource aws_route53_record txt {
 }
 
 resource aws_route53_record domainkey {
-  count   = 3
+  count   = 4
   zone_id = data.aws_route53_zone.zone.zone_id
   name    = "fm${count.index}._domainkey.${data.aws_route53_zone.zone.name}"
   type    = "CNAME"


### PR DESCRIPTION
Add `fm3.{mydomain.com}.dkim.fmhosted.com` to the domainkey records. 

To note, `fm0.{mydomain.com}.dkim.fmhosted.com` does not exist, but removing that record requires a bunch of dropcreates, so I've opted to leave that be.

(Sorry to back-to-back these, the last one was a showstopper, and this one's just getting to parity with the upstream docs 😅  )